### PR TITLE
Fix race condition with multiple inventories

### DIFF
--- a/provider/resource_playbook.go
+++ b/provider/resource_playbook.go
@@ -470,9 +470,6 @@ func resourcePlaybookUpdate(data *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("Temp Inventory File: %s", tempInventoryFile)
 
-	// Get all available temp inventories and pass them as args
-	inventories := providerutils.GetAllInventories(inventoryFileNamePrefix)
-
 	log.Print("[INVENTORIES]:")
 	log.Print(inventories)
 
@@ -480,13 +477,7 @@ func resourcePlaybookUpdate(data *schema.ResourceData, meta interface{}) error {
 
 	args := []string{}
 
-	// Get the rest of args
-	for _, inventory := range inventories {
-		// these arguments are not saved into "args" resource parameter,
-		// but only on this non-resource variable "args"
-		// -- it will not be seen in the state file
-		args = append(args, "-i", inventory)
-	}
+	args = append(args, "-i", tempInventoryFile)
 
 	for _, arg := range argsTf {
 		tmpArg, okay := arg.(string)


### PR DESCRIPTION
I don't see why we are getting all the temp inventory files existing on disk since we are only ever generating 1. This PR fixes that by only using the one we just generated

Fixes #38